### PR TITLE
Update dockerops to use the new docker client api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update && apk add git
 RUN go get github.com/jstemmer/go-junit-report
 
 RUN go get github.com/docker/docker/client
+RUN rm -r /go/src/github.com/docker/docker/vendor
 RUN go get github.com/olebedev/config
 RUN go get github.com/cyverse-de/logcabin
 RUN go get github.com/cyverse-de/model

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add git
 
 RUN go get github.com/jstemmer/go-junit-report
 
-RUN go get github.com/docker/engine-api
+RUN go get github.com/docker/docker/client
 RUN go get github.com/olebedev/config
 RUN go get github.com/cyverse-de/logcabin
 RUN go get github.com/cyverse-de/model
@@ -15,7 +15,6 @@ RUN go get github.com/docker/go-connections/nat
 RUN go get github.com/docker/go-connections/sockets
 RUN go get github.com/docker/go-connections/tlsconfig
 RUN go get github.com/docker/go-units
-RUN go get golang.org/x/net/context
 
 COPY . /go/src/github.com/cyverse-de/dockerops
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN go get github.com/jstemmer/go-junit-report
 
 RUN go get github.com/docker/docker/client
 RUN rm -r /go/src/github.com/docker/docker/vendor
+RUN go get github.com/pkg/errors
 RUN go get github.com/olebedev/config
 RUN go get github.com/cyverse-de/logcabin
 RUN go get github.com/cyverse-de/model

--- a/containers.go
+++ b/containers.go
@@ -7,15 +7,15 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/cyverse-de/logcabin"
 	"github.com/cyverse-de/model"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
-	"github.com/docker/engine-api/types/filters"
 	"github.com/spf13/viper"
 )
 

--- a/containers.go
+++ b/containers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	nat "github.com/docker/go-connections/nat"
 	"github.com/spf13/viper"
 )
 
@@ -470,6 +471,22 @@ func (d *Docker) runContainer(containerID string, stdout, stderr io.Writer) (int
 
 	//wait for container to exit
 	return d.Client.ContainerWait(d.ctx, containerID)
+}
+
+// InspectContainer returns a types.ContainerJSON with details about the container.
+func (d *Docker) InspectContainer(containerID string) (types.ContainerJSON, error) {
+	return d.Client.ContainerInspect(d.ctx, containerID)
+}
+
+// ContainerPortMapping returns a *nat.PortMap of all of the port mappings. This
+// is basically just a convenience function that calls InspectContainer and
+// roots through the return value for the port mapping.
+func (d *Docker) ContainerPortMapping(containerID string) (nat.PortMap, error) {
+	inspection, err := d.InspectContainer(containerID)
+	if err != nil {
+		return nil, err
+	}
+	return inspection.NetworkSettings.Ports, err
 }
 
 // RunStep will run the steps in a job. If a step fails, the function will

--- a/containers_test.go
+++ b/containers_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/cyverse-de/configurate"
 	"github.com/cyverse-de/model"
-	"github.com/docker/engine-api/types/container"
-	"github.com/docker/engine-api/types/strslice"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/strslice"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
Docker deprecated their old engine-api repository and is recommending that projects instead use the client located in the docker repository. This pull request updates dockerops to use the newer version of the client located in the docker repository. 

Corresponding changes have been made in docker-client branches for the image-janitor and road-runner project. Those will have to be updated and merged after this change is merged.